### PR TITLE
メーカーリスト取得機能のAPI実装

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -14,15 +14,35 @@ INSERT INTO locations (location) VALUES
 
 CREATE TABLE IF NOT EXISTS makers (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    maker VARCHAR(255) NOT NULL
+    maker VARCHAR(255) NOT NULL,
+    address VARCHAR(255)
+    );
+
+INSERT INTO makers (maker, address) VALUES
+('ロジステクノス', '東京都港区'),
+('三和テクノロジー', '大阪府箕面市'),
+('大和技研工業', '奈良県大和高田市'),
+('讃岐製作所', '香川県高松市'),
+('富士機械', '静岡県浜松市');
+
+CREATE TABLE IF NOT EXISTS contacts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    maker_id INT,
+    contact_person VARCHAR(255),
+    phone_number VARCHAR(20),
+    email VARCHAR(255),
+    FOREIGN KEY (maker_id) REFERENCES makers(id)
 );
 
-INSERT INTO makers (maker) VALUES
-('ロジステクノス'),
-('三和テクノロジー'),
-('大和技研工業'),
-('讃岐製作所'),
-('富士機械');
+INSERT INTO contacts (maker_id, contact_person, phone_number, email) VALUES
+(1, '田中太郎', '090-1234-5678', 'tanaka@example.com'),
+(2, '佐藤花子', '080-2345-6789', 'satou@example.com'),
+(3, '鈴木一郎', '070-3456-7890', 'suzuki@example.com'),
+(4, '高橋次郎', '060-4567-8901', 'takahashi@example.com'),
+(5, '山田三郎', '050-5678-9012', 'yamada@example.com'),
+(1, '田中花子', '090-8765-4321', 'tanaka-hana@example.com'),
+(2, '佐藤太郎', '080-9876-5432', 'satou-taro@example.com'),
+(3, '鈴木花子', '070-8765-4321', 'suzuki-hana@example.com');
 
 CREATE TABLE IF NOT EXISTS machines (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/maintelog/src/main/java/io/github/keita_yamao/maintelog/MaintelogApplication.java
+++ b/maintelog/src/main/java/io/github/keita_yamao/maintelog/MaintelogApplication.java
@@ -2,20 +2,14 @@ package io.github.keita_yamao.maintelog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 
+@OpenAPIDefinition(info = @Info(title = "PM管理システム"))
 @SpringBootApplication
-@RestController
 public class MaintelogApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(MaintelogApplication.class, args);
 	}
-
-    @GetMapping("/hello")
-    public String hello(@RequestParam(value = "name", defaultValue = "World") String name) {
-      return String.format("こんにちは %s!", name);
-    }
 }

--- a/maintelog/src/main/java/io/github/keita_yamao/maintelog/controller/MainteLogController.java
+++ b/maintelog/src/main/java/io/github/keita_yamao/maintelog/controller/MainteLogController.java
@@ -1,0 +1,42 @@
+package io.github.keita_yamao.maintelog.controller;
+
+import java.util.List;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.github.keita_yamao.maintelog.data.Maker;
+import io.github.keita_yamao.maintelog.service.MainteLogService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+public class MainteLogController {
+    
+    private final MainteLogService mainteLogService;
+    
+    /**
+     * メーカーのリストを取得する
+     * @return  メーカーのリスト
+     */
+    @GetMapping("/makerList")
+    public List<Maker> getMethodName(){
+        return mainteLogService.getMakers();
+    }
+
+    /**
+     * メーカーのIDからメーカーを取得する
+     * @param id メーカーのID
+     * @return メーカー情報
+     */
+    @GetMapping("/maker/{id}")
+    public Maker getMakerById(@PathVariable(name="id") int id) {
+        return mainteLogService.getMakerById(id); 
+    }
+    
+}

--- a/maintelog/src/main/java/io/github/keita_yamao/maintelog/data/Maker.java
+++ b/maintelog/src/main/java/io/github/keita_yamao/maintelog/data/Maker.java
@@ -1,0 +1,18 @@
+package io.github.keita_yamao.maintelog.data;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Value;
+
+@Schema(description = "メーカー情報")
+@Value
+public class Maker {
+    @Schema(description = "メーカーID", example = "1")
+    private int id;
+    @Schema(description = "メーカー名", example = "株式会社〇〇")
+    @Size(max = 255)
+    private String maker;
+    @Schema(description = "住所", example = "東京都港区○○")
+    @Size(max = 255)
+    private String address;
+}

--- a/maintelog/src/main/java/io/github/keita_yamao/maintelog/repository/MakersRepository.java
+++ b/maintelog/src/main/java/io/github/keita_yamao/maintelog/repository/MakersRepository.java
@@ -1,0 +1,24 @@
+package io.github.keita_yamao.maintelog.repository;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import io.github.keita_yamao.maintelog.data.Maker;
+
+/**
+ * メーカー情報テーブルと紐づくリポジトリクラス。
+ */
+@Mapper
+public interface MakersRepository {
+
+   /**
+    * メーカー情報の全件検索。
+    * @return メーカー一覧(全件)
+    */
+   List<Maker> searchMakers();
+
+   /**
+    * 指定されたIDに一致するメーカー情報を検索。
+    * @param id メーカーID
+    * @return メーカー情報
+    */
+   Maker searchMakerById(int id);
+}

--- a/maintelog/src/main/java/io/github/keita_yamao/maintelog/service/MainteLogService.java
+++ b/maintelog/src/main/java/io/github/keita_yamao/maintelog/service/MainteLogService.java
@@ -1,0 +1,32 @@
+package io.github.keita_yamao.maintelog.service;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import io.github.keita_yamao.maintelog.data.Maker;
+import io.github.keita_yamao.maintelog.repository.MakersRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MainteLogService {
+    private final MakersRepository makersRepository;
+
+    /**
+     * メーカー情報の全件取得。
+     * @return メーカー一覧
+     */
+    public List<Maker> getMakers() {
+        return makersRepository.searchMakers();
+    }
+
+    /**
+     * 指定されたIDに一致するメーカー情報を取得。
+     * @param id メーカーID
+     * @return メーカー情報
+     */
+    public Maker getMakerById(int id) {
+        return makersRepository.searchMakerById(id);
+    }
+
+}

--- a/maintelog/src/main/resources/application.properties
+++ b/maintelog/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=maintelog
 
 # DB接続設定
-spring.datasource.url=jdbc:mysql://db:3306/web-app-mentelog
+spring.datasource.url=jdbc:mysql://db:3306/web-app-maintelog
 # ?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Tokyo
 spring.datasource.username=user
 spring.datasource.password=password

--- a/maintelog/src/main/resources/mapper/MakerRepository.xml
+++ b/maintelog/src/main/resources/mapper/MakerRepository.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.github.keita_yamao.maintelog.repository.MakersRepository">
+
+<!-- メーカー情報の全件検索 -->
+<select id="searchMakers" resultType="io.github.keita_yamao.maintelog.data.Maker">
+    SELECT * FROM makers
+</select>
+
+<!-- メーカーIDに基づく検索 -->
+<select id="searchMakerById" parameterType="int" resultType="io.github.keita_yamao.maintelog.data.Maker">
+    SELECT * FROM makers WHERE id = #{id}
+</select>
+
+</mapper>


### PR DESCRIPTION
## 概要
makersテーブルデータをJSON形式で取得するAPIを実装。

## 変更の背景
Issuesリンク
[makersテーブルからメーカー情報を取得する機能のAPI実装](https://github.com/keita-yamao/MainteLog/issues/1)

## 内容
取得できるデータは以下2パターンのAPIを作成。
1. makersテーブルを全件取得
2. makersテーブルのidをリクエストパラメータで取得して1件取得

## 補足情報
<!--レビューや検証のために必要な補足情報、スクリーンショット、懸念点などを記述してください。-->
### 実行結果
1. makersテーブルを全件取得
https://keitayamao.postman.co/workspace/MainteLog~85afb642-134c-4ae0-8e02-7d991bb4ebe3/request/44398211-10deeb80-5291-475b-a760-24d924c3c61a?action=share&creator=44398211

2. makersテーブルのidをリクエストパラメータで取得して1件テーブルデータを取得
https://keitayamao.postman.co/workspace/MainteLog~85afb642-134c-4ae0-8e02-7d991bb4ebe3/request/44398211-789710c3-45df-4088-b45a-0f79d93e2eba?action=share&creator=44398211