### PR TITLE
ヘッダー・サイドバーナビゲーションの実装

### DIFF
--- a/maintelog/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/maintelog/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,5 @@
+{"properties": [{
+  "name": "spring.mvc.welcome-page.enabled",
+  "type": "java.lang.String",
+  "description": "A description for 'spring.mvc.welcome-page.enabled'"
+}]}

--- a/maintelog/src/main/resources/application.properties
+++ b/maintelog/src/main/resources/application.properties
@@ -7,6 +7,9 @@ spring.datasource.username=user
 spring.datasource.password=password
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+# ウェルカムページの有効化
+spring.mvc.welcome-page.enabled=true
+
 # MyBatis
 mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.mapper-locations=classpath:mapper/*.xml 

--- a/maintelog/src/main/resources/static/css/style.css
+++ b/maintelog/src/main/resources/static/css/style.css
@@ -1,0 +1,3 @@
+.sidebar{
+    min-height: calc(100vh - 50px);
+}

--- a/maintelog/src/main/resources/static/index.html
+++ b/maintelog/src/main/resources/static/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="jp">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Maintenance Log</title>
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <!-- Bootstrap Icons -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <!-- Style CSS -->
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <!-- ヘッダー -->
+    <header class="navbar navbar-dark sticky-top bg-dark shadow-sm">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="#">MaineteLog</a>
+            <button class="navbar-toggler d-md-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+        </div>
+    </header>
+    <!-- メインコンテンツ -->
+    <div class="container-fluid">
+        <div class="row">
+                <!-- サイドバーナビゲーション -->
+            <nav id="sidebarMenu" class="col-md-3 col-lg-2 bg-light sidebar offcanvas-md offcanvas-end">
+                <div class="offcanvas-header d-md-none">
+                    <h5 class="offcanvas-title">メニュー</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#sidebarMenu"></button>
+                </div>
+                <div class="pt-3">
+                    <ul class="nav flex-column" id="sidebar-list"></ul>
+                </div>
+            </nav>
+            <!-- 機能画面 -->
+            <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+                <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                    <h1 class="h2">ダッシュボード</h1>
+                </div>
+                <p>ここにダッシュボードの内容が表示されます。</p>
+            </main>
+        </div>
+    </div>
+    <!-- Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <!-- サイドバーの中身を読み込み -->
+    <script src="js/sidebar.js"></script>
+</body>
+</html>

--- a/maintelog/src/main/resources/static/js/sidebar.js
+++ b/maintelog/src/main/resources/static/js/sidebar.js
@@ -1,0 +1,31 @@
+// サイドバーのメニューアイテムを定義
+const menuData = [
+    { name:"ダッシュボード", url:"#",icon:"bi-house-door" },
+    { name:"機械情報管理", url:"#",icon:"bi-tools" },
+    { name:"メーカー情報管理", url:"#",icon:"bi-wechat" },
+]
+
+// サイドバーへメニューアイテムを追加する関数
+function loadSidebar() {
+    // サイドバーのコンテナをIDから取得
+    const sidebarContainer = document.getElementById("sidebar-list");
+    // コンテナが存在しない場合はエラーメッセージを表示して終了
+    if (!sidebarContainer) {
+        console.error("サイドバーのコンテナが見つかりません。");
+        return;
+    }
+    // メニューアイテムのHTMLを生成
+    const menuHtml = menuData.map(item => `
+                            <li class="nav-item">
+                            <a class="nav-link text-dark" href="${item.url}">
+                                <i class="bi ${item.icon} me-2"></i>
+                                ${item.name}
+                            </a>
+                        </li>
+    `).join('');
+    // 生成したHTMLをサイドバーのコンテナに挿入
+    sidebarContainer.innerHTML = menuHtml;
+}
+
+// ページが読み込まれたときにサイドバーを初期化
+document.addEventListener("DOMContentLoaded", loadSidebar);

--- a/maintelog/src/main/resources/static/js/sidebar.js
+++ b/maintelog/src/main/resources/static/js/sidebar.js
@@ -9,14 +9,14 @@ const menuData = [
 function loadSidebar() {
     // サイドバーのコンテナをIDから取得
     const sidebarContainer = document.getElementById("sidebar-list");
-    // コンテナが存在しない場合はエラーメッセージを表示して終了
+    // コンテナが存在しない場合はエラーログを表示して終了
     if (!sidebarContainer) {
         console.error("サイドバーのコンテナが見つかりません。");
         return;
     }
     // メニューアイテムのHTMLを生成
     const menuHtml = menuData.map(item => `
-                            <li class="nav-item">
+                        <li class="nav-item">
                             <a class="nav-link text-dark" href="${item.url}">
                                 <i class="bi ${item.icon} me-2"></i>
                                 ${item.name}


### PR DESCRIPTION
<!--GitHub Pull Request（PR）テンプレート-->
<!--
  PRの提出にあたって、以下のチェックリストに沿って記述してください。
  PRがスムーズにレビューされるよう、必要な情報の記入をお願いします。
-->

## 概要
<!--このPRで実施した変更内容、または追加した機能、修正の概要を記述してください。-->
各画面共通のヘッダーとサイドバーナビゲーションの実装。
サイドバーに各画面へ遷移するメニューを配置。
また、モバイル端末で使用することを考慮しレスポンシブ対応とする。

## 変更の背景
<!--変更が必要となった背景や、解決しようとしているIssueへのリンクを記載してください。  
例: "Fixes #123"-->
[[フロントエンド]ヘッダー・ナビゲーションの作成](https://github.com/keita-yamao/MainteLog/issues/8)

## 変更内容
<!--
- 主な修正点や追加機能
- 変更前と変更後の挙動の違い
-->
各機能へのリンクを設置。
以下内容の画面構成として、サイドバーから遷移できるようにする。
ダッシュボード
機械管理
メーカー・取引先管理

## 追加情報
<!--レビューや検証のために必要な補足情報、スクリーンショット、懸念点などを記述してください。-->
- Bootstrapをベースにデザインをする。
- アプリ共通のデザインや独自設定はstyl.cssにまとめる。
- 繰り返しになるHTMLの構造をコンポーネント化して保守性・可読性の向上を狙う。具体的な部分として、今回のサイドバーメニューのメニューリストを`sidebar.js`として切り出すことにした。
- メインコンテンツ部分については別HTMLを作成し、`index.html`にjavascriptによるDOM操作で生成する。

[実装にあたって考えたこと、躓いたこと](https://github.com/keita-yamao/MainteLog/issues/8#issuecomment-4365708486)


### 実行結果
#### PC
<img width="650" height="435" alt="image" src="https://github.com/user-attachments/assets/886f29ab-ea5c-44ee-bc95-3f8ee3d7ef3a" />

#### モバイル端末
<img width="286" height="393" alt="image" src="https://github.com/user-attachments/assets/b84f2922-6470-48b2-8322-0fe3a3eee259" />
<img width="286" height="393" alt="image" src="https://github.com/user-attachments/assets/0ce78eec-59e4-4403-9fd8-c8b132ac3d90" />


